### PR TITLE
Fix FPC compatibility

### DIFF
--- a/Quick.Files.pas
+++ b/Quick.Files.pas
@@ -263,7 +263,9 @@ type
   function FindDelimiter(const Delimiters, S: string; StartIdx: Integer = 1): Integer;
   {$ENDIF}
   function ConvertDateTimeToFileTime(const DateTime: TDateTime; const UseLocalTimeZone: Boolean): TFileTime;
+  {$ifdef mswindows}
   function ConvertFileTimeToDateTime(const FileTime : TFileTime; const UseLocalTimeZone : Boolean) : TDateTime;
+  {$endif mswindows}
   procedure SetDateTimeInfo(const Path: string; const CreationTime, LastAccessTime, LastWriteTime: PDateTime; const UseLocalTimeZone: Boolean);
   function GetFiles(const Path : string; Recursive : Boolean) : TArray<TDirItem>; overload;
   procedure GetFiles(const Path : string; aAddToList : TDirItemAddProc; Recursive : Boolean); overload;
@@ -1309,8 +1311,10 @@ begin
         diritem.Name := rec.Name;
         diritem.IsDirectory := False;
         diritem.Size := rec.Size;
+        {$ifdef SEARCHREC_USEFINDDATA}
         diritem.CreationDate := ConvertFileTimeToDateTime(rec.FindData.ftCreationTime,True);
         diritem.LastModified := ConvertFileTimeToDateTime(rec.FindData.ftLastWriteTime,True);
+        {$endif SEARCHREC_USEFINDDATA}
         Result := Result + [diritem];
       end
       else
@@ -1336,8 +1340,10 @@ begin
         diritem.Name := rec.Name;
         diritem.IsDirectory := False;
         diritem.Size := rec.Size;
+        {$ifdef SEARCHREC_USEFINDDATA}
         diritem.CreationDate := ConvertFileTimeToDateTime(rec.FindData.ftCreationTime,True);
         diritem.LastModified := ConvertFileTimeToDateTime(rec.FindData.ftLastWriteTime,True);
+        {$endif SEARCHREC_USEFINDDATA}
         aAddToList(diritem);
       end
       else
@@ -1363,8 +1369,10 @@ begin
         diritem.Name := rec.Name;
         diritem.IsDirectory := True;
         diritem.Size := rec.Size;
+        {$ifdef SEARCHREC_USEFINDDATA}
         diritem.CreationDate := ConvertFileTimeToDateTime(rec.FindData.ftCreationTime,True);
         diritem.LastModified := ConvertFileTimeToDateTime(rec.FindData.ftLastWriteTime,True);
+        {$endif SEARCHREC_USEFINDDATA}
         Result := Result + [diritem];
         if Recursive then Result := Result + GetFiles(IncludeTrailingPathDelimiter(Path) + diritem.Name,Recursive);
       end;
@@ -1402,8 +1410,11 @@ begin
         diritem.Name := rec.Name;
         diritem.IsDirectory := False;
         diritem.Size := rec.Size;
+        {$ifdef SEARCHREC_USEFINDDATA}
         diritem.CreationDate := ConvertFileTimeToDateTime(rec.FindData.ftCreationTime,True);
         diritem.LastModified := ConvertFileTimeToDateTime(rec.FindData.ftLastWriteTime,True);
+        {$endif SEARCHREC_USEFINDDATA}
+
         Result := Result + [diritem];
       end
       else if (rec.Name <> '.') and (rec.Name <> '..') then
@@ -1411,8 +1422,11 @@ begin
         diritem.Name := rec.Name;
         diritem.IsDirectory := True;
         diritem.Size := rec.Size;
+        {$ifdef SEARCHREC_USEFINDDATA}
         diritem.CreationDate := ConvertFileTimeToDateTime(rec.FindData.ftCreationTime,True);
         diritem.LastModified := ConvertFileTimeToDateTime(rec.FindData.ftLastWriteTime,True);
+        {$endif SEARCHREC_USEFINDDATA}
+
         Result := Result + [diritem];
         if Recursive then Result := Result + GetFilesAndDirectories(dirpath + diritem.Name,Recursive);
       end;
@@ -1452,8 +1466,11 @@ begin
         diritem.Name := rec.Name;
         diritem.IsDirectory := False;
         diritem.Size := rec.Size;
+        {$ifdef SEARCHREC_USEFINDDATA}
         diritem.CreationDate := ConvertFileTimeToDateTime(rec.FindData.ftCreationTime,True);
         diritem.LastModified := ConvertFileTimeToDateTime(rec.FindData.ftLastWriteTime,True);
+        {$endif SEARCHREC_USEFINDDATA}
+
         aAddToList(diritem);
       end
       else if (rec.Name <> '.') and (rec.Name <> '..') then
@@ -1461,8 +1478,11 @@ begin
         diritem.Name := rec.Name;
         diritem.IsDirectory := True;
         diritem.Size := rec.Size;
+        {$ifdef SEARCHREC_USEFINDDATA}
         diritem.CreationDate := ConvertFileTimeToDateTime(rec.FindData.ftCreationTime,True);
         diritem.LastModified := ConvertFileTimeToDateTime(rec.FindData.ftLastWriteTime,True);
+        {$endif SEARCHREC_USEFINDDATA}
+
         aAddToList(diritem);
         if Recursive then GetFilesAndDirectories(dirpath + diritem.Name,aAddToList,Recursive);
       end;

--- a/Quick.Json.Serializer.pas
+++ b/Quick.Json.Serializer.pas
@@ -164,8 +164,8 @@ type
     //serialize methods
     function SerializeValue(const aValue : TValue) : TJSONValue;
     function SerializeObject(aObject : TObject) : TJSONObject; overload;
-    function SerializeStream(aObject : TObject) : TJSONValue;
     {$IFNDEF FPC}
+    function SerializeStream(aObject : TObject) : TJSONValue;
     function SerializeDynArray(const aValue: TValue; aMaxElements : Integer = -1) : TJsonArray;
     function SerializeRecord(const aValue : TValue) : TJSONValue;
     {$ELSE}
@@ -213,7 +213,9 @@ type
     property UseNullStringsAsEmpty : Boolean read fUseNullStringsAsEmpty write fUseNullStringsAsEmpty;
     function JsonToObject(aType : TClass; const aJson: string) : TObject; overload;
     function JsonToObject(aObject : TObject; const aJson: string) : TObject; overload;
+    {$IFNDEF FPC}
     function JsonStreamToObject(aObject : TObject; aJsonStream : TStream) : TObject;
+    {$ENDIF}
     function ObjectToJson(aObject : TObject; aIndent : Boolean = False): string;
     function ObjectToJsonString(aObject : TObject; aIndent : Boolean = False): string;
     procedure ObjectToJsonStream(aObject : TObject; aStream : TStream);
@@ -450,20 +452,20 @@ begin
   end;
   Result := aRecord;
 end;
+{$ENDIF}
+
 function TRTTIJson.DeserializeStream(aObject: TObject; const aJson: TJSONValue): TObject;
 var
  stream : TStringStream;
 begin
   if fUseBase64Stream then stream := TStringStream.Create(Base64Decode(aJson.Value),TEncoding.Ansi)
-    else stream := TStringStream.Create(aJson.Value,TEncoding.Ansi);
+    else stream := TStringStream.Create(String(aJson.Value),TEncoding.Ansi);
   try
     TStream(aObject).CopyFrom(stream,stream.Size);
   finally
     stream.Free;
   end;
 end;
-
-{$ENDIF}
 
 constructor TRTTIJson.Create(aSerializeLevel : TSerializeLevel; aUseEnumNames : Boolean = True);
 begin


### PR DESCRIPTION
These two files are QuickLogger's dependency, but they currently don't compile with FPC 3.2.X. This pull request attempts to fix that. Tested on 64-bit Linux.