### PR TITLE
Fix bug in DynArray deserialization

### DIFF
--- a/Quick.Json.Serializer.pas
+++ b/Quick.Json.Serializer.pas
@@ -301,7 +301,7 @@ begin
           end
       else
         begin
-          rItemValue := DeserializeType(aObject,rType.Kind,aTypeInfo,aJsonArray.Items[i].Value);
+          rItemValue := DeserializeType(aObject,rType.Kind,rType,aJsonArray.Items[i].Value);
         end;
       end;
       if not rItemValue.IsEmpty then Result.SetArrayElement(i,rItemValue);

--- a/Quick.Json.Serializer.pas
+++ b/Quick.Json.Serializer.pas
@@ -1368,6 +1368,13 @@ begin
       begin
          Result := TJSONValue(SerializeObject(aValue.AsObject));
       end;
+    tkInterface :
+      begin
+        {$IFDEF DELPHIRX10_UP}
+        // Would not work with iOS/Android native interfaces
+        Result := TJSONValue(SerializeObject(aValue.AsInterface as TObject));
+        {$ENDIF}
+      end;
     tkString, tkLString, tkWString, tkUString :
       begin
         Result := TJSONString.Create(aValue.AsString);
@@ -1447,7 +1454,7 @@ begin
         end;
         {$ENDIF}
       end;
-    tkMethod, tkPointer, tkClassRef ,tkInterface, tkProcedure, tkUnknown :
+    tkMethod, tkPointer, tkClassRef, tkProcedure, tkUnknown :
       begin
         //skip these properties
       end

--- a/Quick.YAML.Serializer.pas
+++ b/Quick.YAML.Serializer.pas
@@ -1204,6 +1204,13 @@ begin
         begin
            Result.Value := TYamlValue(Serialize(aValue.AsObject));
         end;
+      tkInterface :
+        begin
+          {$IFDEF DELPHIRX10_UP}
+          // Would not work with all interfaces, like iOS/Android native ones
+          Result.Value := TYamlValue(Serialize(aValue.AsInterface as TObject));
+          {$ENDIF}
+        end;
       tkString, tkLString, tkWString, tkUString :
         begin
           Result.Value := TYamlString.Create(aValue.AsString);
@@ -1270,7 +1277,7 @@ begin
             ctx.Free;
           end;
         end;
-      tkMethod, tkPointer, tkClassRef ,tkInterface, tkProcedure :
+      tkMethod, tkPointer, tkClassRef, tkProcedure :
         begin
           //skip these properties
           //FreeAndNil(Result);

--- a/Quick.YAML.Serializer.pas
+++ b/Quick.YAML.Serializer.pas
@@ -225,7 +225,7 @@ begin
           end
       else
         begin
-          rItemValue := DeserializeType(aObject,rType.Kind,aTypeInfo,aYamlArray.Items[i].Value);
+          rItemValue := DeserializeType(aObject,rType.Kind,rType,aYamlArray.Items[i].Value);
         end;
       end;
       if not rItemValue.IsEmpty then Result.SetArrayElement(i,rItemValue);


### PR DESCRIPTION
The parrent array type was passed to the DeserializeType method, instead of the actual element type.