### PR TITLE
Warning Fixes for Delphi 12 

### DIFF
--- a/Quick.RTTI.Utils.pas
+++ b/Quick.RTTI.Utils.pas
@@ -88,6 +88,7 @@ var
   rmethod: TRttiMethod;
   rinstype: TRttiInstanceType;
 begin
+  Result := CreateInstance<T>([]);
   rtype := fCtx.GetType(TypeInfo(T));
   for rmethod in rtype.GetMethods do
   begin

--- a/Quick.RTTI.Utils.pas
+++ b/Quick.RTTI.Utils.pas
@@ -88,7 +88,7 @@ var
   rmethod: TRttiMethod;
   rinstype: TRttiInstanceType;
 begin
-  Result := CreateInstance<T>([]);
+  Result := Default(T);
   rtype := fCtx.GetType(TypeInfo(T));
   for rmethod in rtype.GetMethods do
   begin

--- a/Quick.Threads.pas
+++ b/Quick.Threads.pas
@@ -685,7 +685,7 @@ begin
   try
     for obj in FQueue do
     begin
-      if TypeInfo(T) = TypeInfo(TObject) then PObject(@obj){$IFNDEF FPC}.DisposeOf;{$ELSE}.Free;{$ENDIF}
+      if TypeInfo(T) = TypeInfo(TObject) then PObject(@obj).Free;
     end;
 
     SetLength(FQueue,0);

--- a/Quick.Threads.pas
+++ b/Quick.Threads.pas
@@ -685,7 +685,7 @@ begin
   try
     for obj in FQueue do
     begin
-      if TypeInfo(T) = TypeInfo(TObject) then PObject(@obj).Free;
+      if TypeInfo(T) = TypeInfo(TObject) then PObject(@obj){$ifndef FPC}{$IFDEF  DELPHIRX12_UP}.Free{$ELSE}.DisposeOf{$ENDIF}{$ELSE}.Free{$ENDIF};
     end;
 
     SetLength(FQueue,0);


### PR DESCRIPTION
Added a default for Quick.RTTI.Utils.pas TRTTI.CreateInstance<T>(const Args: array of TValue): T; since Delphi 12 now has a warning. Likely the use of generics prevented the 'return value of function might be undefined' warning from showing in previous compiler versions. Also added Check for Delphi 12 to use Free in QuickThread.pas TThreadedQueueCS<T>.Clear; as Delphi 12 deprecated DisposeOf.