### PR TITLE
correct the Result from RunConsoleCommand()

### DIFF
--- a/Quick.Console.pas
+++ b/Quick.Console.pas
@@ -881,12 +881,12 @@ begin
             end;
             //Application.ProcessMessages;
           until (dRunning <> WAIT_TIMEOUT);
+          GetExitCodeProcess(piProcess.hProcess,Result);
         finally
           CloseHandle(piProcess.hProcess);
           CloseHandle(piProcess.hThread);
         end;
       end;
-      GetExitCodeProcess(piProcess.hProcess,Result);
     finally
       CloseHandle(hRead);
       CloseHandle(hWrite);


### PR DESCRIPTION
the GetExitCodeProcess was called after the CloseHandle(piProcess.hProcess).
Moved GetExitCodeProcess before the CloseHandle.